### PR TITLE
Change String trait name to avoid error with PHP7

### DIFF
--- a/src/Vectorface/MySQLite/MySQL/StringFn.php
+++ b/src/Vectorface/MySQLite/MySQL/StringFn.php
@@ -7,7 +7,7 @@ namespace Vectorface\MySQLite\MySQL;
  *
  * http://dev.mysql.com/doc/refman/5.7/en/string-functions.html
  */
-trait String
+trait StringFn
 {
 
      /**

--- a/src/Vectorface/MySQLite/MySQLite.php
+++ b/src/Vectorface/MySQLite/MySQLite.php
@@ -12,7 +12,7 @@ use Vectorface\MySQLite\MySQL\Comparison;
 use Vectorface\MySQLite\MySQL\DateTime;
 use Vectorface\MySQLite\MySQL\Flow;
 use Vectorface\MySQLite\MySQL\Numeric;
-use Vectorface\MySQLite\MySQL\String;
+use Vectorface\MySQLite\MySQL\StringFn;
 
 /**
  * Provides some compatibility functions, allowing SQLite to mimic some MySQL functions.
@@ -29,7 +29,7 @@ class MySQLite
     use DateTime;
     use Flow;
     use Numeric;
-    use String;
+    use StringFn;
 
     /**
      * Get a list of MySQL compatibility functions currently provided by this class.


### PR DESCRIPTION
I encountered this error when running a unit test under php 7:

``` bash
PHP Fatal error:  Cannot use Vectorface\MySQLite\MySQL\String as String because 'String' is a special class name
```

I have tested this change, and it fixes the above error.
