### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,9 @@ before_script:
     - composer install
 
 script:
-    - ./vendor/bin/phpunit --coverage-clover=coverage.clover
-    - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm-3.30" ]; then wget https://scrutinizer-ci.com/ocular.phar; fi;'
-    - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm-3.30" ]; then php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi'
-    - sh -c 'if [ -n "$CODECLIMATE_REPO_TOKEN" -a "$TRAVIS_PHP_VERSION" != "hhvm-3.30" ]; then vendor/bin/test-reporter --coverage-report=coverage.clover; fi'
+ - ./vendor/bin/phpunit --coverage-clover=coverage.clover
 
-sudo: false
+after_script:
+ - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm-3.30" ]; then wget https://scrutinizer-ci.com/ocular.phar; fi;'
+ - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm-3.30" ]; then php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi'
+ - sh -c 'if [ -n "$CODECLIMATE_REPO_TOKEN" -a "$TRAVIS_PHP_VERSION" != "hhvm-3.30" ]; then vendor/bin/test-reporter --coverage-report=coverage.clover; fi'

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,11 @@
     "license": "MIT",
     "autoload": {
         "psr-4": {
-            "Vectorface\\MySQLite\\": "src/Vectorface/MySQLite/",
+            "Vectorface\\MySQLite\\": "src/Vectorface/MySQLite/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
             "Vectorface\\Tests\\MySQLite\\": "tests/Vectorface/Tests/MySQLite/"
         }
     },

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,7 +5,6 @@
 	colors="true"
 	backupStaticAttributes="false"
 	bootstrap="vendor/autoload.php"
-	strict="true"
 >
 	<testsuites>
 		<testsuite name="MySQL compatibility functions for SQLite">

--- a/src/Vectorface/MySQLite/MySQL/StringFn.php
+++ b/src/Vectorface/MySQLite/MySQL/StringFn.php
@@ -32,7 +32,7 @@ trait StringFn
     {
         $args = func_get_args();
         $seperator = array_shift($args);
-        $str = implode($seperator,$args);
+        $str = implode($seperator, $args);
         return $str;
     }
 }

--- a/tests/Vectorface/Tests/MySQLite/MySQLiteTest.php
+++ b/tests/Vectorface/Tests/MySQLite/MySQLiteTest.php
@@ -5,14 +5,14 @@ namespace Vectorface\Tests\MySQLite;
 use InvalidArgumentException;
 use PDO;
 use PDOException;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Vectorface\MySQLite\MySQLite;
 use Vectorface\Tests\MySQLite\Util\FakePDO;
 
 /**
  * Test MySQLite; This could be split up into individual function categories later.
  */
-class MySQLiteTest extends PHPUnit_Framework_TestCase
+class MySQLiteTest extends TestCase
 {
     /**
      * Test miscellaneous compatibility functions.
@@ -73,7 +73,7 @@ class MySQLiteTest extends PHPUnit_Framework_TestCase
             /* Expected */
         }
 
-        $this->assertTrue($pdo === MySQLite::createFunctions($pdo));
+        $this->assertSame($pdo, MySQLite::createFunctions($pdo));
         $this->assertEquals(3, $pdo->query("SELECT BIT_OR(1, 2)")->fetch(PDO::FETCH_COLUMN));
     }
 
@@ -83,7 +83,7 @@ class MySQLiteTest extends PHPUnit_Framework_TestCase
     public function testSelectiveCreateFunctions()
     {
         $pdo = new PDO("sqlite::memory:", null, null, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
-        $this->assertTrue($pdo === MySQLite::createFunctions($pdo, ['bit_or']));
+        $this->assertSame($pdo, MySQLite::createFunctions($pdo, ['bit_or']));
         $this->assertEquals(3, $pdo->query("SELECT BIT_OR(1, 2)")->fetch(PDO::FETCH_COLUMN));
         try {
             $pdo->query("SELECT UNIX_TIMESTAMP()");
@@ -98,8 +98,8 @@ class MySQLiteTest extends PHPUnit_Framework_TestCase
      */
     public function testGetFunctionList()
     {
-        $this->assertTrue(in_array("bit_or", MySQLite::getFunctionList()));
-        $this->assertTrue(in_array("unix_timestamp", MySQLite::getFunctionList()));
+        $this->assertContains("bit_or", MySQLite::getFunctionList());
+        $this->assertContains("unix_timestamp", MySQLite::getFunctionList());
     }
 
     /**
@@ -123,13 +123,13 @@ class MySQLiteTest extends PHPUnit_Framework_TestCase
     public function testConcatWS()
     {
         $expected = 'test1|test2|test4';
-        $test = MySQLite::mysql_concat_ws("|","test1","test2","test4");
-        $this->assertEquals($expected,$test);
+        $test = MySQLite::mysql_concat_ws("|", "test1", "test2", "test4");
+        $this->assertEquals($expected, $test);
 
         $pdo = new PDO("sqlite::memory:", null, null, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
         MySQLite::createFunctions($pdo);
         $result = $pdo->query('SELECT CONCAT_WS("|","test1","test2","test4")')->fetch(PDO::FETCH_COLUMN);
-        $this->assertEquals($expected,$result);
+        $this->assertEquals($expected, $result);
     }
 
      /**

--- a/tests/Vectorface/Tests/MySQLite/Util/FakePDO.php
+++ b/tests/Vectorface/Tests/MySQLite/Util/FakePDO.php
@@ -31,10 +31,6 @@ class FakePDO extends \PDO
      */
     public function getAttribute($attr)
     {
-        if (isset($this->attributes[$attr])) {
-            return $this->attributes[$attr];
-        }
-
-        return parent::getAttribute($attr);
+        return isset($this->attributes[$attr]) ? $this->attributes[$attr] : parent::getAttribute($attr);
     }
 }


### PR DESCRIPTION
# Changed log
- Organize Travis CI setting to avoid invalid token.
- Organize the `autoload` and `autoload-dev` namespace in `composer.json` setting.
- Remove `strict` attribute in `phpunit.xml` setting.
- Using the class-based PHPUnit namespace to be compatible with latest PHPUnit version.
- Using the `assertSame` to check the `$pdo` class is the same.
- Using the `assertContains` to check whether specific key is existed in the result array.