### PR TITLE
Fix compatibility with PHP 8.1

### DIFF
--- a/src/Vectorface/MySQLite/MySQL/StringFn.php
+++ b/src/Vectorface/MySQLite/MySQL/StringFn.php
@@ -46,8 +46,8 @@ trait StringFn
     public static function mysql_format()
     {
         $args = func_get_args();
-        $number = $args[0] ?? 0;
-        $decimals = $args[1] ?? 0;
+        $number = isset($args[0]) ? $args[0] : 0.0;
+        $decimals = isset($args[0]) ? $args[0] : 0;
         return number_format($number, $decimals);
     }
 }

--- a/src/Vectorface/MySQLite/MySQL/StringFn.php
+++ b/src/Vectorface/MySQLite/MySQL/StringFn.php
@@ -46,8 +46,8 @@ trait StringFn
     public static function mysql_format()
     {
         $args = func_get_args();
-        $number = $args[0];
-        $decimals = $args[1];
+        $number = $args[0] ?? 0;
+        $decimals = $args[1] ?? 0;
         return number_format($number, $decimals);
     }
 }


### PR DESCRIPTION
```
Deprecated: number_format(): Passing null to parameter #1 ($num) of type float is deprecated in vendor/vectorface/mysqlite/src/Vectorface/MySQLite/MySQL/StringFn.php on line 51
```