### PR TITLE
UNIX_TIMETAMP: Add support for zero timestamps

### DIFF
--- a/src/Vectorface/MySQLite/MySQL/DateTime.php
+++ b/src/Vectorface/MySQLite/MySQL/DateTime.php
@@ -47,6 +47,8 @@ trait DateTime
     {
         if (!isset($date)) {
             return time();
+        } elseif (count_chars(str_replace([":", "-", " "], "", $date), 3) === "0") {
+            return 0; /* MySQL's implementation returns zero for 0000-00-00 00:00:00 and similar */
         }
 
         return strtotime($date);

--- a/tests/Vectorface/Tests/MySQLite/MySQLiteTest.php
+++ b/tests/Vectorface/Tests/MySQLite/MySQLiteTest.php
@@ -46,6 +46,8 @@ class MySQLiteTest extends TestCase
         $this->assertEquals(718613, MySQLite::mysql_to_days("1967-07-01"));
         $this->assertEquals(735599, MySQLite::mysql_to_days("2014-01-01"));
         $this->assertEquals(time(), MySQLite::mysql_unix_timestamp());
+        $this->assertEquals(0, MySQLite::mysql_unix_timestamp("0000-00-00 00:00:00"));
+        $this->assertEquals(0, MySQLite::mysql_unix_timestamp("0000-00-00"));
         $time = time();
         $this->assertEquals($time, MySQLite::mysql_unix_timestamp(date("Y-m-d H:i:s")));
     }


### PR DESCRIPTION
Emulate MySQL's treatment of zero timestamps:

```
MySQL> select UNIX_TIMESTAMP(ts) FROM some_table WHERE ts='0000-00-00 00:00:00' LIMIT 1;
+--------------------+
| UNIX_TIMESTAMP(ts) |
+--------------------+
|                  0 |
+--------------------+

1 row in set (0.000 sec)
```